### PR TITLE
Restore backdrop asset loading

### DIFF
--- a/src/data/sandboxAssets.js
+++ b/src/data/sandboxAssets.js
@@ -1,9 +1,13 @@
-const backdropImageModules = typeof import.meta.glob === 'function'
-  ? import.meta.glob('../../assets/*.png', {
-      eager: true,
-      import: 'default',
-    })
-  : {};
+let backdropImageModules = {};
+
+try {
+  backdropImageModules = import.meta.glob('../../assets/*.png', {
+    eager: true,
+    import: 'default',
+  });
+} catch {
+  // Node-based tests do not provide Vite's import.meta.glob helper.
+}
 
 export const sandboxAssets = [
   { id: 'bunny', emoji: '🐰', label: 'Bunny', unlockLevel: 1 },


### PR DESCRIPTION
## Summary
- restore Vite backdrop asset loading from the root assets folder
- keep Node-side imports safe by catching missing import.meta.glob support
- preserve the backdrop assets tab by preventing the asset list from resolving empty at runtime

## Verification
- npm run build